### PR TITLE
Move simple_soa_demo to OracleLinux 7.7

### DIFF
--- a/servers.yaml
+++ b/servers.yaml
@@ -5,7 +5,7 @@
 defaults:
   domain_name:     example.com
   cpucount:         1
-  box:              enterprisemodules/centos-7.3-x86_64-nocm
+  box:              enterprisemodules/ol-7.7-x86_64-nocm
   virtualboxorafix: enable
 #
 # The default settings for all ML nodes


### PR DESCRIPTION
Story details: https://app.clubhouse.io/enterprise-modules-bv/story/334